### PR TITLE
Use Platform instead of Sdk as runtime

### DIFF
--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -1,6 +1,6 @@
 ---
 app-id: com.usebottles.bottles
-runtime: org.gnome.Sdk
+runtime: org.gnome.Platform
 runtime-version: '3.38'
 sdk: org.gnome.Sdk
 add-extensions:


### PR DESCRIPTION
Using Sdk as runtime only makes sense for apps used for code development like IDE.

This will save 1GB of install size for users.

If you need anything that is in Sdk but not in Platform then you should bundle it within app manually.