### PR TITLE
Remove socket=session-bus

### DIFF
--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -31,7 +31,6 @@ finish-args:
 - --share=ipc
 - --socket=fallback-x11
 - --socket=pulseaudio
-- --socket=session-bus
 - --filesystem=~/Games:ro
 - --filesystem=~/wineprefixes:ro
 - --filesystem=~/.Bottles:ro
@@ -46,6 +45,9 @@ finish-args:
 - --filesystem=/media
 - --device=all
 - --system-talk-name=org.freedesktop.UDisks2
+- --talk-name=org.freedesktop.Notifications
+- --talk-name=org.gtk.vfs
+- --talk-name=org.gtk.vfs.*
 x-compat-i386-opts:
   prepend-pkg-config-path: "/app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig"
   ldflags: "-L/app/lib32"


### PR DESCRIPTION
And replace it with only necessary named service on the session bus.

In future if you need to extend names you can run Bottles with:
```
flatpak run --log-session-bus com.usebottles.bottles
```
and find in this output necessary names which required by app.

Fix: #34 
