### PR TITLE
manifest: enable --allow=devel

### DIFF
--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -5,6 +5,7 @@ runtime-version: '41'
 command: bottles
 
 finish-args:
+  - --alow=devel
   - --allow=multiarch
   - --share=network
   - --share=ipc


### PR DESCRIPTION
Apparently, Wine utilizes syscalls such as ptrace() in specific cases, and because Flatpak disallows such syscall by default, the installation of components such as .NET 3.5, end up failing.

See: https://github.com/bottlesdevs/Bottles/issues/864