### PR TITLE
xdg-data Access by Default

### DIFF
--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -20,6 +20,7 @@ finish-args:
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/usr/lib/extensions/vulkan/OBSVkCapture/bin/
   - --require-version=1.1.2
+  - --filesystem=xdg-data
 
 inherit-extensions:
   - org.freedesktop.Platform.GL32


### PR DESCRIPTION
Allow access to `xdg-data` on the user's machine by default to support the `Add desktop entry` feature out of the box. Note that the applicable path (e.g. `~/.local/share/applications` on most distros) must still be present.

This has been tested locally and works as expected (with the mentioned caveat in place of course).