### PR TITLE
Set GST_PLUGIN_SYSTEM_PATH environment variable

### DIFF
--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -20,6 +20,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/usr/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin/
+  - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
   - --require-version=1.1.2
 
 inherit-extensions:


### PR DESCRIPTION
Set the variable such that it accommodates both 64-bit and 32-bit programs. 64-bit gstreamer plugins have a higher precedence by being placed first in the variable, meaning warnings about wrong ELF class will be shown to 32-bit users.

Copied from: https://github.com/flathub/net.lutris.Lutris/blob/1d560df42f3b73216855e0d822b6981b1167eb96/net.lutris.Lutris.yml#L27