### PR TITLE
Added automatic build of Bottles in beta

### DIFF
--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -3,7 +3,7 @@ sdk: org.gnome.Sdk
 runtime: org.gnome.Platform
 base: org.winehq.Wine
 base-version: stable-22.08
-runtime-version: "43"
+runtime-version: '43'
 command: bottles
 
 finish-args:
@@ -33,11 +33,11 @@ inherit-extensions:
 add-extensions:
   org.gnome.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: "43"
+    version: '43'
 
   org.gnome.Platform.Compat.i386.Debug:
     directory: lib/debug/lib/i386-linux-gnu
-    version: "43"
+    version: '43'
     no-autodownload: true
 
   com.valvesoftware.Steam.Utility:
@@ -71,8 +71,8 @@ cleanup:
   - /share/gtk-doc
   - /share/man
   - /share/pkgconfig
-  - "*.la"
-  - "*.a"
+  - '*.la'
+  - '*.a'
 
 cleanup-commands:
   - mkdir -p /app/utils
@@ -98,13 +98,22 @@ modules:
         url: https://github.com/yaml/pyyaml/archive/refs/tags/6.0.tar.gz
         sha256: f33eaba25d8e0c1a959bbf00655198c287dfc5868f5b7b01e401eaa1796cc778
     modules:
-    - name: libyaml
-      config-opts:
-        - --disable-static
-      sources:
-        - type: archive
-          url: https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz
-          sha256: c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4
+      - name: libyaml
+        config-opts:
+          - --disable-static
+        sources:
+          - type: archive
+            url: https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz
+            sha256: c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4
+
+  - name: PycURL
+    buildsystem: simple
+    build-commands:
+      - python3 setup.py install --prefix=/app --root=/
+    sources:
+      - type: git
+        url: https://github.com/pycurl/pycurl.git
+        tag: REL_7_45_1
 
   - name: python-requests
     buildsystem: simple
@@ -241,24 +250,10 @@ modules:
         url: https://github.com/freedesktop/xdpyinfo/archive/refs/tags/xdpyinfo-1.3.2.tar.gz
         sha256: 4c6942cb55e965f1192c0e2efc78429e2f4281cc2bc185d6ea09d609f32c51de
 
+
+
   # Libraries
   # ----------------------------------------------------------------------------
-
-  - name: mesa-glu
-    config-opts: &mesa_glu_opts
-      - --disable-static
-    sources: &mesa_glu_sources
-      - type: archive
-        url: https://mesa.freedesktop.org/archive/glu/glu-9.0.2.tar.xz
-        sha256: 6e7280ff585c6a1d9dfcdf2fca489251634b3377bfc33c29e4002466a38d02d4
-
-  - name: mesa-glu-32bit
-    build-options:
-      arch:
-        x86_64: *compat_i386_opts
-    config-opts: *mesa_glu_opts
-    sources: *mesa_glu_sources
-
   - name: rpcsvc-proto
     buildsystem: autotools
     sources:
@@ -276,7 +271,7 @@ modules:
         PERL5LIB: /app/lib/perl5/
         PERL_MM_OPT: INSTALL_BASE=/app
     cleanup:
-      - "*"
+      - '*'
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz
@@ -320,8 +315,18 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/jwestman/blueprint-compiler
-        tag: 'v0.4.0'
+        tag: v0.4.0
         commit: 75a6d95988736ec0471d22ceb07579c0cedac2ad
+
+  - name: vkbasalt-cli
+    buildsystem: simple
+    build-commands:
+      - python3 setup.py install --prefix=/app --root=/
+    sources:
+      - type: git
+        url: https://gitlab.com/TheEvilSkeleton/vkbasalt-cli
+        tag: v3.0
+        commit: 68d37866d7e732923fb628b81dcb0a808e9ccfe6
 
   # Bottles components
   # ----------------------------------------------------------------------------
@@ -358,7 +363,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/mirkobrombin/FVS
-        tag: "0.3.4"
+        tag: 0.3.4
         commit: 4e76dc54028a88099c72ec3a925b5f059f442d05
         x-checker-data:
           type: json
@@ -383,15 +388,17 @@ modules:
       - cp -a * /app/etc/runtime/
     sources:
       - type: archive
-        url: https://github.com/bottlesdevs/runtime/releases/download/0.5/runtime.tar.gz
-        sha256: 00f7e57f0b54057343cfe49de52690c7b3024771478fc75cfe55c2154e13834f
+        url: https://github.com/bottlesdevs/runtime/releases/download/0.6/runtime.tar.gz
+        sha256: f2b47012cde0a7e9c65ca4d793d19a2f9d3fe68b76dd457839e62ec34f214528
 
   - name: bottles
     builddir: true
     buildsystem: meson
-    config-opts:
-      - -Ddevel=true
     sources:
-    - type: git
-      url: https://github.com/bottlesdevs/Bottles
-      commit: d34df9ea1ed2b07185a8688e2ff32826caf30fd4
+      - type: git
+        url: https://github.com/bottlesdevs/Bottles
+        commit: e8262ebc0897e60ce78ca713ce3bf194f5b9191e
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/bottlesdevs/Bottles/commits
+          commit-query: ".[0].sha"

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "only-arches": ["x86_64"]
+    "only-arches": ["x86_64"],
+    "automerge-flathubbot-prs": true
 }

--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,2 +1,0 @@
-/app/lib32
-/app/lib/i386-linux-gnu


### PR DESCRIPTION
I copied the manifest file from `master`, adding the `x-checker-data` to track the latest commit. It should also auto-merge PRs that the bot creates, only for the beta branch.

This should enable flathub-beta version of Bottles to follow the main branch of the repository, making bleeding-edge fixes available easily for users.

It should only trigger on commits from the `main` branch upstream, but it might need a bit of testing