### PR TITLE
Add gamemode patch (release 51.10)

### DIFF
--- a/gamemode.patch
+++ b/gamemode.patch
@@ -1,0 +1,13 @@
+diff --git a/common/common-pidfds.c b/common/common-pidfds.c
+index 00929f70..61442e34 100644
+--- a/common/common-pidfds.c
++++ b/common/common-pidfds.c
+@@ -58,6 +58,8 @@ static int pidfd_open(pid_t pid, unsigned int flags)
+ {
+ 	return (int)syscall(__NR_pidfd_open, pid, flags);
+ }
++#else
++#include <sys/pidfd.h>
+ #endif
+ 
+ /* pidfd functions */


### PR DESCRIPTION
Will be required for [51.10](https://github.com/bottlesdevs/Bottles/pull/3099) to build, and for future release as long as there's no new gamemode version including [this](https://github.com/FeralInteractive/gamemode/commit/4934191b1928ef695c3e8af21e75781f8591745f) commit.

Relevant issue: https://github.com/FeralInteractive/gamemode/issues/429