### PR TITLE
Unbreak 32-bit Vulkan support on NVIDIA

### DIFF
--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -20,6 +20,7 @@ finish-args:
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/usr/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin/:/usr/lib/extensions/vulkan/gamescope/bin/
   - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
+  - --env=XDG_CONFIG_DIRS=/app/etc/xdg:/etc/xdg:/usr/lib/x86_64-linux-gnu/GL # The last path here enables 32-bit Vulkan support on NVIDIA GPUs.
   - --require-version=1.1.2
 
 inherit-extensions:


### PR DESCRIPTION
A [recent change](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/commit/d55b7cb0e5269b5bd4b0d86ac8df2f77966451ce) in the NVIDIA GL extension stopped including the Vulkan ICD file in the GL32 extension, in order to prevent the Vulkan Loader (`libvulkan.so`) from incorrectly [reporting duplicated GPUs](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/112) to Vulkan apps.

However, that fix ended up [breaking 32-bit Vulkan support](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/342) for some multiarch apps (such as this one).

One way to fix this, is by modifying `XDG_CONFIG_DIRS` to include the path where the NVIDIA ICD file (`nvidia_icd.json`) is, which in turn helps the 32-bit Vulkan Loader [find it](https://vulkan.lunarg.com/doc/view/1.4.309.0/linux/LoaderDriverInterface.html#driver-discovery-on-linux).

Steam has been pretty much [this same solution](https://github.com/flathub/com.valvesoftware.Steam/commit/ae87f47cd15969d5d3019088b4e89341b9a2fbe7) for almost 5 years.