### PR TITLE
update fvs2 to 0.1.5

### DIFF
--- a/com.usebottles.bottles.fvs2-deps.yaml
+++ b/com.usebottles.bottles.fvs2-deps.yaml
@@ -7,8 +7,8 @@ build-commands:
 sources:
   - type: git
     url: https://github.com/fvs-lab/fvs2.git
-    tag: v0.1.3
-    commit: 42776c1fa53548ed1fc8ff994d37ede4c7e5de3d
+    tag: v0.1.5
+    commit: a33950c91b35fa8e0b80398502b26bfe565bea47
     dest: fvs2
   - type: git
     url: https://github.com/fvs-lab/core.git


### PR DESCRIPTION
Commiting snapshots is currently broken as it errors with 
```
Versioning error: FVS commit failed: ERR: unknown shorthand flag: -v
```

63.2 assumes that the fvs2 version should be 0.1.5 (with commit https://github.com/bottlesdevs/Bottles/commit/9c32e7fe43ae24cb581f57a6a9a07a8298c49470), but that's only true for dev manifest. The used version is 0.1.3, which doesn't have the verbose flag added in https://github.com/fvs-lab/fvs2/commit/a33950c91b35fa8e0b80398502b26bfe565bea47.