### PR TITLE
refactor: standardize ~/.local/share path to xdg-data

### DIFF
--- a/com.usebottles.bottles.yml
+++ b/com.usebottles.bottles.yml
@@ -16,7 +16,7 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --device=all
-  - --filesystem=~/.local/share/umu:create
+  - --filesystem=xdg-data/umu:create
   - --filesystem=~/Games/umu:create
   - --system-talk-name=org.freedesktop.UDisks2
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib/i386-linux-gnu


### PR DESCRIPTION
Uses the standardized `xdg-data` rather than hardcoded `~/.local/share`

https://github.com/Open-Wine-Components/umu-launcher/blob/e2b203a1fdd2af9f35166f5713cb3f85d72587e2/umu/umu_run.py#L823-L832

https://docs.flatpak.org/en/latest/sandbox-permissions.html#filesystem-access